### PR TITLE
Default to spectral LPA for clustering

### DIFF
--- a/callbacks.py
+++ b/callbacks.py
@@ -15,7 +15,7 @@ def register_callbacks(app):
         Input('clustering-store', 'data')
     )
     def _render_tab_content(tab, graph_data, clustering_store):
-        clustering_method = clustering_store.get('clustering_method', 'lpa') if clustering_store else 'lpa'
+        clustering_method = clustering_store.get('clustering_method', 'spectral_lpa') if clustering_store else 'spectral_lpa'
         clustering_step = clustering_store.get('clustering_step', 0) if clustering_store else 0
         clustering_node_order = clustering_store.get('clustering_node_order', '') if clustering_store else ''
         custom_code = clustering_store.get('custom_code') if clustering_store else None


### PR DESCRIPTION
## Summary
- use `'spectral_lpa'` as the default clustering method when no store data is present

## Testing
- `python -m py_compile callbacks.py graph_utils.py eigen_app.py eigen_documentation.py`
- `python - <<'PY'
from graph_utils import render_tab_content, default_graph

# mimic callbacks with no clustering store
layout = render_tab_content('tab-clustering', default_graph(), 'spectral_lpa', 0, '', None)
print('layout type', type(layout))
PY`
- `python - <<'PY'
from graph_utils import default_graph, run_clustering
labels = run_clustering(default_graph(), 'spectral_lpa')
print('labels', labels)
PY`


------
https://chatgpt.com/codex/tasks/task_e_684a47b8fd8483308a5671aa519f3f63