### PR TITLE
Fix duplicate controls

### DIFF
--- a/eigen_app.py
+++ b/eigen_app.py
@@ -13,14 +13,7 @@ from graph_utils import (
     empty_graph,
     default_graph,
     render_tab_content,
-    update_graph_store,
-    run_clustering,
-    eigen_decomposition_controls,
-    node_edge_controls,
-    settings_controls,
-    graph_visualization_layout,
-    graph_generator_controls,
-    clustering_controls
+    update_graph_store
 )
 from callbacks import register_callbacks
 

--- a/graph_utils.py
+++ b/graph_utils.py
@@ -35,16 +35,12 @@ def get_tab_layout(tab, graph_data, clustering_method='spectral_lpa', clustering
         from graph_utils import default_graph
         graph_data = default_graph()
     if tab == 'tab-graph':
-        # Graph Tools: Graph visualization, then all settings (generator, laplacian, ek-pairs, node/edge)
+        # Only return the visualization area. All controls are created once in
+        # ``eigen_app.py`` and shown/hidden via wrappers, so duplicating them
+        # here leads to Dash ID conflicts.
         return html.Div([
-            graph_visualization_layout(graph_data),
-            html.Div([
-                graph_generator_controls(),
-                laplacian_hyperparameters_controls(),
-                ek_pairs_controls(),
-                node_edge_controls()
-            ], style={"width": "40%", "overflowY": "auto", "height": "100vh", "padding": "10px", "borderLeft": "1px solid #ccc"})
-        ], style={"display": "flex"})
+            graph_visualization_layout(graph_data)
+        ])
     elif tab == 'tab-clustering':
         cluster_labels = None
         y_prime = None
@@ -58,17 +54,11 @@ def get_tab_layout(tab, graph_data, clustering_method='spectral_lpa', clustering
             except CustomClusteringError as exc:
                 print(exc)
                 cluster_labels, y_prime = None, None
-        # Only show the main graph and clustering controls, not matrix/stacked/agg vizzes
+        # Only show the main graph. The associated controls are provided by the
+        # global wrappers defined in ``eigen_app.py``.
         return html.Div([
-            html.Div([
-                dcc.Graph(id="graph", style={"height": "60vh"}),
-            ], style={"width": "70%"}),
-            html.Div([
-                graph_generator_controls(),
-                node_edge_controls(),
-                clustering_controls(tab)
-            ], style={"width": "30%", "overflowY": "auto", "height": "100vh", "padding": "10px", "borderLeft": "1px solid #ccc"})
-        ], style={"display": "flex"})
+            dcc.Graph(id="graph", style={"height": "60vh"})
+        ])
     elif tab == 'tab-docs':
         from eigen_documentation import DOCS_CONTENT
         return html.Div(DOCS_CONTENT, style={"padding": "20px"})


### PR DESCRIPTION
## Summary
- remove unused control component imports
- stop duplicating control components in tab layouts

## Testing
- `python -m py_compile eigen_app.py callbacks.py graph_utils.py eigen_documentation.py`

------
https://chatgpt.com/codex/tasks/task_e_684b97b89d208330a37515d7d48af710